### PR TITLE
ColoResourceUsageDetector

### DIFF
--- a/lint-checks-android/src/main/java/com/uber/lintchecks/android/ColorResourceUsageDetector.kt
+++ b/lint-checks-android/src/main/java/com/uber/lintchecks/android/ColorResourceUsageDetector.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.lintchecks.android
 
 import com.android.resources.ResourceFolderType

--- a/lint-checks-android/src/main/java/com/uber/lintchecks/android/UiDetectorUtils.kt
+++ b/lint-checks-android/src/main/java/com/uber/lintchecks/android/UiDetectorUtils.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.lintchecks.android
 
 import org.w3c.dom.Attr

--- a/lint-checks-android/src/test/java/com/uber/lintchecks/android/ColorResourceUsageDetectorTest.kt
+++ b/lint-checks-android/src/test/java/com/uber/lintchecks/android/ColorResourceUsageDetectorTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.lintchecks.android
 
 import com.android.tools.lint.checks.infrastructure.TestLintTask


### PR DESCRIPTION
Ref #4 

Mostly a port of the monorepo but i've removed two things:
1. The whitelist that let some colors fly
2. If the file was called `ub__themeless` we'd let it fly. No need for that here