### PR TITLE
Specify lint API + Upgrade lint

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@
 def versions = [
         kotlin: '1.3.41',
         support: '27.1.1',
-        lint: '26.5.0',
+        lint: '26.5.3',
         errorProne      : '2.3.3',
         gjf             : '1.7',
         ktlint: '0.31.0'

--- a/lint-checks-rxjava/src/main/java/com/uber/lintchecks/rxjava/LintRegistry.kt
+++ b/lint-checks-rxjava/src/main/java/com/uber/lintchecks/rxjava/LintRegistry.kt
@@ -16,6 +16,7 @@
 package com.uber.lintchecks.rxjava
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.google.auto.service.AutoService
 
@@ -25,4 +26,6 @@ class LintRegistry : IssueRegistry() {
       RxJavaDistinctDetector.ISSUE,
       RxJavaToSingleDetector.ISSUE
   )
+
+  override val api: Int = CURRENT_API
 }

--- a/lint-checks/src/main/java/com/uber/lintchecks/LintRegistry.kt
+++ b/lint-checks/src/main/java/com/uber/lintchecks/LintRegistry.kt
@@ -16,6 +16,7 @@
 package com.uber.lintchecks
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.google.auto.service.AutoService
 
@@ -26,4 +27,6 @@ class LintRegistry : IssueRegistry() {
       StringToCaseNoLocaleDetector.ISSUE,
       SystemCurrentTimeMillisDetector.ISSUE
   )
+
+  override val api: Int = CURRENT_API
 }


### PR DESCRIPTION
Turns out that the default `api` is set to -1 which disables the lint